### PR TITLE
adds bdd testing api for Space.messaging.Api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Space Testing [![Build Status](https://travis-ci.org/meteor-space/testing.svg?branch=master)](https://travis-ci.org/CodeAdventure/space-testing)
+# Space Testing [![Circle CI](https://circleci.com/gh/meteor-space/testing.svg?style=svg)](https://circleci.com/gh/meteor-space/testing)
 
 Helpers for Testing Space Applications and Modules.
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,14 @@
+machine:
+  node:
+    version: 0.10.33
+  pre:
+    - curl https://install.meteor.com | /bin/sh
+dependencies:
+  pre:
+    - npm install -g mgp
+    - npm install -g spacejam
+  override:
+    - mgp
+test:
+  override:
+    - spacejam test-packages ./

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,8 @@
 machine:
   node:
     version: 0.10.33
+  environment:
+    PACKAGE_DIRS: packages
   pre:
     - curl https://install.meteor.com | /bin/sh
 dependencies:

--- a/package.js
+++ b/package.js
@@ -27,6 +27,7 @@ Package.onUse(function(api) {
     'source/bdd/test-api.coffee',
     'source/bdd/aggregates-bdd-api.coffee',
     'source/bdd/stores-bdd-api.coffee',
+    'source/bdd/messaging-api-bdd-api.coffee',
   ]);
 
 });

--- a/source/bdd/aggregates-bdd-api.coffee
+++ b/source/bdd/aggregates-bdd-api.coffee
@@ -6,16 +6,6 @@ Space.Module.registerBddApi (app, systemUnderTest) ->
 
 class Space.Module.AggregateTest
 
-  _app: null
-  _aggregateClass: null
-  _aggregate: null
-  _messages: null
-  _commitStore: null
-  _eventBus: null
-  _publishedEvents: null
-  _expectation: null
-  _expectedEvents: null
-
   constructor: (@_app) ->
     @_app.start()
     @fakeDates = sinon.useFakeTimers('Date')
@@ -62,7 +52,10 @@ class Space.Module.AggregateTest
     @_cleanup()
 
   _addPublishedEvents: (event) =>
-    @_publishedEvents.push(event) if not @_isSendingTestMessages
+    unless @_ignoreNextEvent
+      @_publishedEvents.push(event)
+    else
+      @_ignoreNextEvent = false
 
   _cleanup: ->
     @fakeDates.restore()
@@ -73,4 +66,5 @@ class Space.Module.AggregateTest
       if message instanceof Space.messaging.Command
         @_app.send(message)
       else
-        @_app.publish(message, ignoreHooks: true)
+        @_ignoreNextEvent = true
+        @_app.publish message

--- a/source/bdd/messaging-api-bdd-api.coffee
+++ b/source/bdd/messaging-api-bdd-api.coffee
@@ -1,0 +1,46 @@
+# BDD api for testing Space.messaging.Api
+
+Space.Module.registerBddApi (app, systemUnderTest) ->
+  if !Space.messaging? then return
+  return new ApiTest(app) if isSubclassOf(systemUnderTest, Space.messaging.Api)
+
+class ApiTest
+
+  constructor: (@_app) ->
+    @_app.start()
+    @fakeDates = sinon.useFakeTimers('Date')
+    @_apiArgs = []
+    @_sentCommands = []
+    @_expectedCommands = []
+    @_commandBus = @_app.injector.get 'Space.messaging.CommandBus'
+
+  send: (@_apiArgs...) -> return this
+
+  expect: (expectedCommands) ->
+    if _.isFunction(expectedCommands)
+      @_expectedCommands = expectedCommands()
+    else
+      @_expectedCommands = expectedCommands
+    @_test = =>
+      @_callApi()
+      expect(@_sentCommands).toMatch @_expectedCommands
+    @_run()
+
+  expectToFailWith: (expectedError) ->
+    @_test = => expect(@_callApi).to.throw expectedError.message
+    @_run()
+
+  _run: ->
+    @_commandBus.onSend (command) => @_sentCommands.push(command)
+    @_test()
+    @_cleanup()
+
+  _cleanup: ->
+    @fakeDates.restore()
+    @_app.reset()
+
+  _callApi: =>
+    if @_apiArgs.length is 1
+      Space.messaging.Api.send(@_apiArgs[0]) # it's a command
+    else
+      Meteor.call.apply(null, @_apiArgs)

--- a/source/bdd/messaging-api-bdd-api.coffee
+++ b/source/bdd/messaging-api-bdd-api.coffee
@@ -14,7 +14,11 @@ class ApiTest
     @_expectedCommands = []
     @_commandBus = @_app.injector.get 'Space.messaging.CommandBus'
 
-  send: (@_apiArgs...) -> return this
+  send: (command) ->
+    @_apiArgs = [command]
+    return this
+
+  call: (@_apiArgs...) -> return this
 
   expect: (expectedCommands) ->
     if _.isFunction(expectedCommands)


### PR DESCRIPTION
This PR adds a first draft of a BDD api for testing `Space.messaging.Api`.

Here is a simple api class that is used for integration testing in space-messaging:

``` coffeescript
class @MyApi extends Space.messaging.Api
  methods: -> [
    # Simulate some simple method validation
    'MyCommand': (_, command) -> @send(command) if command.value.name is 'good-value'
  ]
```

Here are two simple example tests:

``` javascript
 it("sends a handled command on the server-side command bus if passes validation", function () {
   MyApp.test(MyApi).send(this.command).expect([this.command]);
 });

 it("does not send a handled command on the server-side command bus if fails validation", function () {
  this.command.value = new MyValue({ name: 'bad-value' });
  MyApp.test(MyApi).send(this.command).expect([]);
 });
```

Other maintenance changes:
- Switched to CircleCI for testing
- Simplified / refactored code for aggregate BDD tests
