### PR TITLE
Feature/add given method for api tests

### DIFF
--- a/git-packages.json
+++ b/git-packages.json
@@ -9,6 +9,6 @@
   },
   "space:event-sourcing": {
     "git":"https://github.com/meteor-space/event-sourcing.git",
-    "branch": "develop"
+    "branch": "fix/process-meta-data-correlations"
   }
 }

--- a/package.js
+++ b/package.js
@@ -16,6 +16,7 @@ Package.onUse(function(api) {
     'reactive-var',
     'reactive-dict',
     'tracker',
+    'ecmascript',
     'space:base@3.1.1',
     'practicalmeteor:munit@2.1.5'
   ]);
@@ -40,6 +41,7 @@ Package.onTest(function(api) {
     'check',
     'mongo',
     'underscore',
+    'ecmascript',
     'space:event-sourcing@2.1.0',
     'space:testing',
     'practicalmeteor:munit@2.1.5'
@@ -52,7 +54,8 @@ Package.onTest(function(api) {
   ]);
 
   api.addFiles([
-    'tests/bdd/aggregates-bdd-api.tests.coffee'
+    'tests/bdd/aggregates-bdd-api.tests.coffee',
+    'tests/bdd/api-bdd.tests.js'
   ], 'server');
 
 });

--- a/source/bdd/messaging-api-bdd-api.coffee
+++ b/source/bdd/messaging-api-bdd-api.coffee
@@ -14,6 +14,22 @@ class ApiTest
     @_sentCommands = []
     @_expectedCommands = []
     @_commandBus = @_app.injector.get 'Space.messaging.CommandBus'
+    @_commitStore = @_app.injector.get 'Space.eventSourcing.CommitStore'
+
+  given: (data) ->
+    # Turn it into an array
+    messages = [].concat(data)
+    events = []
+    commands = []
+    # Split messages up into events and commands
+    for message in messages
+      events.push(message) if message instanceof Space.messaging.Event
+      commands.push(message) if message instanceof Space.messaging.Command
+    # We have to add a commit to simulate historic events / commands
+    changes = events: events, commands: commands
+    aggregateId = data[0].sourceId
+    version = data[0].version ? 1
+    @_commitStore.add changes, aggregateId, version - 1
 
   send: (command) ->
     @_apiArgs = [command]

--- a/source/bdd/messaging-api-bdd-api.coffee
+++ b/source/bdd/messaging-api-bdd-api.coffee
@@ -36,6 +36,7 @@ class ApiTest
       for message in messages
         @_app.publish(message) if message instanceof Space.messaging.Event
         @_app.send(message) if message instanceof Space.messaging.Command
+    return this
 
   send: (command) ->
     @_apiArgs = [command]

--- a/source/bdd/test-api.coffee
+++ b/source/bdd/test-api.coffee
@@ -18,6 +18,8 @@ Space.Module.test = Space.Application.test = (systemUnderTest, app=null) ->
         requiredModules: [this.publishedAs]
       })
     appInstance = new app()
+  else
+    appInstance = app
 
   for api in registeredBddApis
     returnValue = api(appInstance, systemUnderTest)

--- a/tests/bdd/aggregates-bdd-api.tests.coffee
+++ b/tests/bdd/aggregates-bdd-api.tests.coffee
@@ -118,12 +118,14 @@ describe 'Space.testing - aggregates', ->
         version: 1
         title: @title
         maxItems: @maxItems
+        meta: {}
       )
       new TodoAdded(
         sourceId: @id
         version: 2
         todoId: todoId
         title: todoTitle
+        meta: {}
       )
     ])
 

--- a/tests/bdd/api-bdd.tests.js
+++ b/tests/bdd/api-bdd.tests.js
@@ -1,0 +1,44 @@
+describe("Space.testing - apis", function() {
+
+  let ApiTest = Space.namespace('ApiTest');
+
+  Space.messaging.Event.extend(ApiTest, 'MyTestEvent', {
+    onExtending() { this.type('ApiTest.MyTestEvent'); }
+  });
+
+  Space.messaging.Command.extend(ApiTest, 'MyTestCommand', {
+    onExtending() { this.type('ApiTest.MyTestCommand'); }
+  });
+
+  Space.messaging.Api.extend(ApiTest, 'Api');
+
+  Space.Application.extend(ApiTest, 'MyApp', {
+    configuration: { appId: 'ApiTest.MyApp' },
+    requiredModules: ['Space.eventSourcing'],
+    registerHandler() {
+      this.commandBus.registerHandler.apply(this.commandBus, arguments);
+    }
+  });
+
+  describe("#given", function() {
+
+    it("allows to setup the SUT with a historic commit", function() {
+      let myApp = new ApiTest.MyApp();
+      let eventSpy = sinon.spy();
+      let commandSpy = sinon.spy();
+      let event = new ApiTest.MyTestEvent({ sourceId: '123' });
+      let command = new ApiTest.MyTestCommand({ targetId: '123' });
+
+      myApp.subscribeTo(ApiTest.MyTestEvent, eventSpy);
+      myApp.registerHandler(ApiTest.MyTestCommand, commandSpy);
+
+      ApiTest.MyApp.test(ApiTest.Api, myApp)
+      .given([event, command]);
+
+      expect(eventSpy).to.have.been.calledWithMatch(event);
+      expect(commandSpy).to.have.been.calledWithMatch(command);
+    });
+
+  });
+
+});

--- a/tests/bdd/api-bdd.tests.js
+++ b/tests/bdd/api-bdd.tests.js
@@ -2,19 +2,38 @@ describe("Space.testing - apis", function() {
 
   let ApiTest = Space.namespace('ApiTest');
 
-  Space.messaging.Event.extend(ApiTest, 'MyTestEvent', {
-    onExtending() { this.type('ApiTest.MyTestEvent'); }
+  Space.messaging.Event.extend(ApiTest, 'MySetupEvent', {
+    onExtending() { this.type('ApiTest.MySetupEvent'); }
   });
 
-  Space.messaging.Command.extend(ApiTest, 'MyTestCommand', {
-    onExtending() { this.type('ApiTest.MyTestCommand'); }
+  Space.messaging.Command.extend(ApiTest, 'MySetupCommand', {
+    onExtending() { this.type('ApiTest.MySetupCommand'); }
   });
 
-  Space.messaging.Api.extend(ApiTest, 'Api');
+  Space.messaging.Command.extend(ApiTest, 'MyApiCommand', {
+    onExtending() { this.type('ApiTest.MyApiCommand'); }
+  });
+
+  Space.messaging.Api.extend(ApiTest, 'Api', {
+    methods() {
+      return [{
+        'ApiTest.MyApiCommand'(context, command) {
+          this.send(command);
+        }
+      }];
+    }
+  });
 
   Space.Application.extend(ApiTest, 'MyApp', {
     configuration: { appId: 'ApiTest.MyApp' },
     requiredModules: ['Space.eventSourcing'],
+    singletons: ['ApiTest.Api'],
+    afterInitialize() {
+      this.setupCommandHandler = sinon.spy();
+      this.apiCommandHandler = sinon.spy();
+      this.registerHandler(ApiTest.MySetupCommand, this.setupCommandHandler);
+      this.registerHandler(ApiTest.MyApiCommand, this.apiCommandHandler);
+    },
     registerHandler() {
       this.commandBus.registerHandler.apply(this.commandBus, arguments);
     }
@@ -25,18 +44,30 @@ describe("Space.testing - apis", function() {
     it("allows to setup the SUT with a historic commit", function() {
       let myApp = new ApiTest.MyApp();
       let eventSpy = sinon.spy();
-      let commandSpy = sinon.spy();
-      let event = new ApiTest.MyTestEvent({ sourceId: '123' });
-      let command = new ApiTest.MyTestCommand({ targetId: '123' });
+      let event = new ApiTest.MySetupEvent({ sourceId: '123' });
+      let command = new ApiTest.MySetupCommand({ targetId: '123' });
 
-      myApp.subscribeTo(ApiTest.MyTestEvent, eventSpy);
-      myApp.registerHandler(ApiTest.MyTestCommand, commandSpy);
+      myApp.subscribeTo(ApiTest.MySetupEvent, eventSpy);
 
       ApiTest.MyApp.test(ApiTest.Api, myApp)
       .given([event, command]);
 
       expect(eventSpy).to.have.been.calledWithMatch(event);
-      expect(commandSpy).to.have.been.calledWithMatch(command);
+      expect(myApp.setupCommandHandler).to.have.been.calledWithMatch(command);
+    });
+
+  });
+
+  describe("#send", function() {
+
+    it("allows to send a command to the api", function() {
+      let setupEvent = new ApiTest.MySetupEvent({ sourceId: '123' });
+      let setupCommand = new ApiTest.MySetupCommand({ targetId: '123' });
+      let apiCommand = new ApiTest.MyApiCommand({ targetId: '543' });
+      ApiTest.MyApp.test(ApiTest.Api)
+      .given([setupEvent, setupCommand])
+      .send(apiCommand)
+      .expect([apiCommand]);
     });
 
   });


### PR DESCRIPTION
This PR adds a `given` method for api BDD testing which takes an array of events and commands that should be used to simulate a historic commit in the system under test. Be aware that this triggers the complete stack -> commit store / commit publisher are all involved.
