### PR TITLE
update testing api to handle Space.domain.Exceptions correctly

### DIFF
--- a/git-packages.json
+++ b/git-packages.json
@@ -10,5 +10,9 @@
   "space:event-sourcing": {
     "git":"https://github.com/meteor-space/event-sourcing.git",
     "branch": "develop"
+  },
+  "space:domain": {
+    "git":"https://github.com/meteor-space/domain.git",
+    "branch": "develop"
   }
 }

--- a/source/bdd/aggregates-bdd-api.coffee
+++ b/source/bdd/aggregates-bdd-api.coffee
@@ -15,6 +15,13 @@ class AggregateTest
     @_expectedEvents = []
     @_commitStore = @_app.injector.get 'Space.eventSourcing.CommitStore'
     @_eventBus = @_app.injector.get 'Space.messaging.EventBus'
+    # Don't add stack traces to Space.Error during testing -> hard to stub!
+    @_extractErrorPropsBackup = Space.Error.prototype.extractErrorProperties
+    test = this
+    Space.Error.prototype.extractErrorProperties = ->
+      data = test._extractErrorPropsBackup.apply(this, arguments)
+      delete data.stack
+      return data
 
   given: (data) ->
     if _.isArray(data)
@@ -62,6 +69,8 @@ class AggregateTest
 
   _cleanup: ->
     @fakeDates.restore()
+    # Restore error stack traces after testing
+    Space.Error.prototype.extractErrorProperties = @_extractErrorPropsBackup
     @_app.stop()
 
   _sendMessagesThroughApp: =>


### PR DESCRIPTION
This removes the stack traces in Space.Error instances
because these cannot easily be stubbed in test code
