### PR TITLE
Feature/ignore certain event properties

### DIFF
--- a/source/assertions/match-array-of-structs.coffee
+++ b/source/assertions/match-array-of-structs.coffee
@@ -4,6 +4,8 @@ chai.use (chai, utils) ->
 
     actual = this._obj
 
+    untestedProperties = ['timestamp', 'version', 'meta']
+
     for struct, index in actual
       for key, type of struct.fields()
         if _.isFunction(expected[index][key])
@@ -11,6 +13,9 @@ chai.use (chai, utils) ->
           check struct[key], expected[index][key]
           # Copy over the actual value, so that they are equal
           expected[index][key] = struct[key]
+        else if _.contains(untestedProperties, key)
+          delete expected[index][key]
+          delete struct[key]
 
     # Turn the structs into JSON so that we can output them
     # in readable structure in the tests.

--- a/tests/bdd/aggregates-bdd-api.tests.coffee
+++ b/tests/bdd/aggregates-bdd-api.tests.coffee
@@ -118,15 +118,11 @@ describe 'Space.testing - aggregates', ->
     .expect([
       new TodoListCreated(
         sourceId: @id
-        version: 1
-        timestamp: Date
         title: @title
         maxItems: @maxItems
       )
       new TodoAdded(
         sourceId: @id
-        version: 2
-        timestamp: Date
         todoId: todoId
         title: todoTitle
       )
@@ -138,13 +134,11 @@ describe 'Space.testing - aggregates', ->
     .given([
       new TodoListCreated(
         sourceId: @id
-        version: 1
         title: @title
         maxItems: @maxItems
       ),
       new TodoAdded(
         sourceId: @id
-        version: 2
         todoId: '1'
         title: 'first'
       )
@@ -156,6 +150,5 @@ describe 'Space.testing - aggregates', ->
       new Space.domain.Exception({
         thrower: 'TodoList'
         error: new TooManyItems(@maxItems, @title)
-        timestamp: Date
       })
     ])


### PR DESCRIPTION
This PR introduces logic to the `matchArrayOfStructs` assertion to exclude `timestamp`, `version` and `meta` to be compared in BDD tests. This reduces most of the boilerplate :wink: 
