### PR TITLE
Feature/contain array of structs assertion

### DIFF
--- a/package.js
+++ b/package.js
@@ -29,6 +29,7 @@ Package.onUse(function(api) {
     'source/assertions/extend.coffee',
     'source/assertions/to_match.coffee',
     'source/assertions/match-array-of-structs.coffee',
+    'source/assertions/contain-array-of-structs.coffee',
     'source/bdd/test-api.coffee',
     'source/bdd/aggregates-bdd-api.coffee',
     'source/bdd/stores-bdd-api.coffee',

--- a/source/assertions/contain-array-of-structs.coffee
+++ b/source/assertions/contain-array-of-structs.coffee
@@ -1,0 +1,28 @@
+chai.use (chai, utils) ->
+
+  chai.Assertion.addMethod 'containArrayOfStructs', (expected) ->
+
+    actual = this._obj
+
+    untestedProperties = ['timestamp', 'version', 'meta']
+
+    for struct, index in actual
+      for key, type of struct.fields()
+        if _.isFunction(expected[index][key])
+          # Check that the actual value is of the expected type
+          check struct[key], expected[index][key]
+          # Copy over the actual value, so that they are equal
+          expected[index][key] = struct[key]
+        else if _.contains(untestedProperties, key)
+          delete expected[index][key]
+          delete struct[key]
+
+    # Format for error messages
+    actualString = JSON.stringify(actual, null, 2)
+
+    for struct, index in expected
+      structString = JSON.stringify(struct, null, 2)
+      this.assert(
+        _.any(actual, (item) -> _.isEqual(item, struct) ),
+        "Expected Struct #{structString} not contained in #{actualString}"
+      )

--- a/source/assertions/contain-array-of-structs.coffee
+++ b/source/assertions/contain-array-of-structs.coffee
@@ -2,20 +2,25 @@ chai.use (chai, utils) ->
 
   chai.Assertion.addMethod 'containArrayOfStructs', (expected) ->
 
-    actual = this._obj
+    # Filter out structs we don't need to test for
+    actual = _.filter(this._obj, (actualStruct) ->
+      _.any(expected, (expectedStruct) ->
+        _.isEqual(expectedStruct.toString(), actualStruct.toString())
+      )
+    )
 
     untestedProperties = ['timestamp', 'version', 'meta']
 
-    for struct, index in actual
-      for key, type of struct.fields()
+    for actualStruct, index in actual
+      for key, type of actualStruct.fields()
         if _.isFunction(expected[index][key])
           # Check that the actual value is of the expected type
-          check struct[key], expected[index][key]
+          check actualStruct[key], expected[index][key]
           # Copy over the actual value, so that they are equal
-          expected[index][key] = struct[key]
+          expected[index][key] = actualStruct[key]
         else if _.contains(untestedProperties, key)
           delete expected[index][key]
-          delete struct[key]
+          delete actualStruct[key]
 
     # Format for error messages
     actualString = JSON.stringify(actual, null, 2)
@@ -24,5 +29,5 @@ chai.use (chai, utils) ->
       structString = JSON.stringify(struct, null, 2)
       this.assert(
         _.any(actual, (item) -> _.isEqual(item, struct) ),
-        "Expected Struct #{structString} not contained in #{actualString}"
+        "Expected Struct #{struct.toString()} #{structString} not contained in #{actualString}"
       )

--- a/source/bdd/aggregates-bdd-api.coffee
+++ b/source/bdd/aggregates-bdd-api.coffee
@@ -46,7 +46,7 @@ class AggregateTest
       @_expectedEvents = expectedEvents
     @_test = =>
       @_sendMessagesThroughApp()
-      expect(@_publishedEvents).to.matchArrayOfStructs @_expectedEvents
+      expect(@_publishedEvents).to.containArrayOfStructs @_expectedEvents
     @_run()
 
   expectToFailWith: (expectedError) ->

--- a/source/bdd/messaging-api-bdd-api.coffee
+++ b/source/bdd/messaging-api-bdd-api.coffee
@@ -27,7 +27,7 @@ class ApiTest
       @_expectedCommands = expectedCommands
     @_test = =>
       @_callApi()
-      expect(@_sentCommands).matchArrayOfStructs @_expectedCommands
+      expect(@_sentCommands).containArrayOfStructs @_expectedCommands
     @_run()
 
   expectToFailWith: (expectedError) ->


### PR DESCRIPTION
This PR switches the underlying assertion used to test Aggregates and Apis, so that events published external to the SUT don’t need to be included in the expectations.
