### PR TITLE
Chore/ignore schema version

### DIFF
--- a/source/assertions/contain-array-of-structs.coffee
+++ b/source/assertions/contain-array-of-structs.coffee
@@ -9,7 +9,7 @@ chai.use (chai, utils) ->
       )
     )
 
-    untestedProperties = ['timestamp', 'version', 'meta']
+    untestedProperties = ['timestamp', 'version', 'meta', 'schemaVersion']
 
     for actualStruct, index in actual
       for key, type of actualStruct.fields()

--- a/source/assertions/match-array-of-structs.coffee
+++ b/source/assertions/match-array-of-structs.coffee
@@ -4,7 +4,7 @@ chai.use (chai, utils) ->
 
     actual = this._obj
 
-    untestedProperties = ['timestamp', 'version', 'meta']
+    untestedProperties = ['timestamp', 'version', 'meta', 'schemaVersion']
 
     for struct, index in actual
       for key, type of struct.fields()


### PR DESCRIPTION
Simply adds `schemaVersion` to the array of `untestedProperties` so we don't have to explicitly test this property in every `matchArrayOfStructs` or `containsArrayOfStructs` test
